### PR TITLE
Colordata Struct

### DIFF
--- a/libraw/src/colordata.rs
+++ b/libraw/src/colordata.rs
@@ -1,0 +1,218 @@
+use std::{convert::TryInto, slice};
+
+use libraw_sys as sys;
+use sys::{
+    LibRaw_colorspace_LIBRAW_COLORSPACE_AdobeRGB, LibRaw_colorspace_LIBRAW_COLORSPACE_Unknown,
+    LibRaw_colorspace_LIBRAW_COLORSPACE_sRGB,
+};
+
+#[allow(non_snake_case)]
+pub struct Colordata {
+    pub curve: [u16; 65536],
+    pub black: u32,
+
+    // These are all from cblack
+    pub black_per_channel: [u32; 4],
+    pub black_block_width: u32,
+    pub black_block_height: u32,
+    pub black_block_data: [u32; 4098],
+
+    pub maximum: u32,
+
+    //NOTE: The docs lnked below call this an unsigned, but it's a signed 64?
+    // https://www.libraw.org/docs/API-datastruct.html#libraw_colordata_t
+    pub linear_max: [i64; 4],
+    pub fmaximum: f32,
+    pub fnorm: f32,
+    pub white: [[u16; 8]; 8],
+    pub cam_xyz: [[f32; 3]; 4],
+    // WB coefficients as shot
+    pub cam_mul: [f32; 4],
+    // WB coefficients for Daylight
+    pub pre_mul: [f32; 4],
+    pub cmatrix: [[f32; 4]; 3], // Not clear what this is
+    pub rgb_cam: [[f32; 4]; 3],
+
+    pub phase_one_data: PhaseOne,
+    pub flash_used: f32, // Why the heck is this a float. Can it be a bool?
+    pub canon_ev: f32,
+
+    pub model2: [i8; 64], // NOTE: How to stringify this? Should I?
+    pub UniqueCameraModel: [i8; 64],
+    pub LocalizedCameraModel: [i8; 64],
+
+    pub profile: Vec<u8>,
+    pub black_stat: [u32; 8],
+
+    pub dng_color: [DngColor; 2],
+    pub dng_levels: DngLevels,
+
+    pub WB_Coeffs: [[i32; 4]; 256],
+    pub WBCT_Coeffs: [[f32; 5]; 64],
+    pub as_shot_wb_applied: bool,
+
+    pub P1_color: [PhaseOneColor; 2],
+    pub raw_bps: u32,
+
+    pub exif_color_space: ExifColorSpace,
+}
+
+impl Colordata {
+    pub(crate) fn new(colordata: sys::libraw_colordata_t) -> Self {
+        let profile = unsafe {
+            slice::from_raw_parts(
+                colordata.profile as *mut u8,
+                colordata.profile_length as usize,
+            )
+        }
+        .to_vec();
+
+        Colordata {
+            curve: colordata.curve,
+            black: colordata.black,
+            black_per_channel: colordata.cblack[0..4].try_into().unwrap(),
+            black_block_width: colordata.cblack[4],
+            black_block_height: colordata.cblack[5],
+            black_block_data: colordata.cblack[6..].try_into().unwrap(),
+            maximum: colordata.maximum,
+            linear_max: colordata.linear_max,
+            fmaximum: colordata.fmaximum,
+            fnorm: colordata.fnorm,
+            white: colordata.white,
+            cam_xyz: colordata.cam_xyz,
+            cam_mul: colordata.cam_mul,
+            pre_mul: colordata.pre_mul,
+            cmatrix: colordata.cmatrix,
+            rgb_cam: colordata.rgb_cam,
+            phase_one_data: colordata.phase_one_data.into(),
+            flash_used: colordata.flash_used,
+            canon_ev: colordata.canon_ev,
+            model2: colordata.model2,
+            UniqueCameraModel: colordata.UniqueCameraModel,
+            LocalizedCameraModel: colordata.LocalizedCameraModel,
+            profile,
+            black_stat: colordata.black_stat,
+            dng_color: [colordata.dng_color[0].into(), colordata.dng_color[1].into()],
+            dng_levels: colordata.dng_levels.into(),
+            as_shot_wb_applied: colordata.as_shot_wb_applied == 1,
+            P1_color: [colordata.P1_color[0].into(), colordata.P1_color[1].into()],
+            WB_Coeffs: colordata.WB_Coeffs,
+            WBCT_Coeffs: colordata.WBCT_Coeffs,
+            raw_bps: colordata.raw_bps,
+            exif_color_space: ExifColorSpace::from_sys(colordata.ExifColorSpace),
+        }
+    }
+}
+
+pub struct PhaseOne {
+    pub format: i32,
+    pub key_off: i32,
+    pub tag_21a: i32,
+    pub t_black: i32,
+    pub split_col: i32,
+    pub black_col: i32,
+    pub split_row: i32,
+    pub black_row: i32,
+    pub tag_210: f32,
+}
+
+impl From<sys::ph1_t> for PhaseOne {
+    fn from(ph1: sys::ph1_t) -> Self {
+        PhaseOne {
+            format: ph1.format,
+            key_off: ph1.key_off,
+            tag_21a: ph1.tag_21a,
+            t_black: ph1.t_black,
+            split_col: ph1.split_col,
+            black_col: ph1.black_col,
+            split_row: ph1.split_row,
+            black_row: ph1.black_row,
+            tag_210: ph1.tag_210,
+        }
+    }
+}
+
+pub struct DngColor {
+    pub parsedfields: u32,
+    pub illuminant: u16,
+    pub calibration: [[f32; 4]; 4],
+    pub colormatrix: [[f32; 3]; 4],
+    pub forwardmatrix: [[f32; 4]; 3],
+}
+
+impl From<sys::libraw_dng_color_t> for DngColor {
+    fn from(dng: sys::libraw_dng_color_t) -> Self {
+        Self {
+            parsedfields: dng.parsedfields,
+            illuminant: dng.illuminant,
+            calibration: dng.calibration,
+            colormatrix: dng.colormatrix,
+            forwardmatrix: dng.forwardmatrix,
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+pub struct DngLevels {
+    pub parsedfields: u32,
+    //TODO: Separate out fields of cblack like in the main Colordata struct
+    pub cblack: [u32; 4104],
+    pub black: u32,
+    pub fcblack: [f32; 4104],
+    pub fblack: f32,
+    pub whitelevel: [u32; 4],
+    pub default_crop: [u32; 4],
+    pub preview_colorspace: u32,
+    pub analogbalance: [f32; 4],
+    pub baseline_exposure: f32,
+    pub LinearResponseLimit: f32,
+}
+
+impl From<sys::libraw_dng_levels_t> for DngLevels {
+    fn from(dng: sys::libraw_dng_levels_t) -> Self {
+        Self {
+            parsedfields: dng.parsedfields,
+            cblack: dng.dng_cblack,
+            black: dng.dng_black,
+            fcblack: dng.dng_fcblack,
+            fblack: dng.dng_fblack,
+            whitelevel: dng.dng_whitelevel,
+            default_crop: dng.default_crop,
+            preview_colorspace: dng.preview_colorspace,
+            analogbalance: dng.analogbalance,
+            baseline_exposure: dng.baseline_exposure,
+            LinearResponseLimit: dng.LinearResponseLimit,
+        }
+    }
+}
+
+pub struct PhaseOneColor {
+    pub romm_cam: [f32; 9],
+}
+
+impl From<sys::libraw_P1_color_t> for PhaseOneColor {
+    fn from(p1: sys::libraw_P1_color_t) -> Self {
+        Self {
+            romm_cam: p1.romm_cam,
+        }
+    }
+}
+
+#[allow(non_camel_case_types)]
+pub enum ExifColorSpace {
+    Unknown,
+    sRGB,
+    AdobeRgb,
+}
+
+impl ExifColorSpace {
+    fn from_sys(sys_int: i32) -> Self {
+        #[allow(non_upper_case_globals)]
+        match sys_int as u32 {
+            LibRaw_colorspace_LIBRAW_COLORSPACE_Unknown => ExifColorSpace::Unknown,
+            LibRaw_colorspace_LIBRAW_COLORSPACE_AdobeRGB => ExifColorSpace::AdobeRgb,
+            LibRaw_colorspace_LIBRAW_COLORSPACE_sRGB => ExifColorSpace::sRGB,
+            _ => panic!(),
+        }
+    }
+}

--- a/libraw/src/lib.rs
+++ b/libraw/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/libraw-rs/0.0.4")]
 
 pub use self::bit_depth::BitDepth;
+pub use self::colordata::Colordata;
 pub use self::error::{Error, Result};
 pub use self::image::ProcessedImage;
 pub use self::processor::Processor;
@@ -8,6 +9,7 @@ pub use self::rawimage::RawImage;
 pub use self::sizes::Sizes;
 
 mod bit_depth;
+mod colordata;
 mod error;
 mod image;
 mod processor;

--- a/libraw/src/rawimage.rs
+++ b/libraw/src/rawimage.rs
@@ -1,4 +1,4 @@
-use crate::{Processor, Sizes};
+use crate::{Colordata, Processor, Sizes};
 use std::ops::Deref;
 use std::slice;
 
@@ -15,6 +15,10 @@ impl RawImage {
 
     pub fn sizes(&self) -> Sizes {
         Sizes::new(unsafe { (*self.processor.inner).sizes })
+    }
+
+    pub fn color(&self) -> Colordata {
+        Colordata::new(unsafe { (*self.processor.inner).color })
     }
 }
 


### PR DESCRIPTION
This has been a bit coming it seems! The issue, #3, is from January 7th of this year and now it's almost January again! I was using the re-exported struct for a good while before I decided to finally copy it into Rust. It was an interesting undertaking. I don't think I'm done yet, but it's been sitting in my fork for a bit and there are some things I'd like your advice about. Notes below.

__Libraw's cblack:__ `unsigned cblack[4102]`
> Per-channel black level correction. First 4 values are per-channel correction, next two are black level pattern block size, than cblack[4]*cblack[5] correction values (for indexes [6....6+cblack[4]*cblack[5]).

Going on the documentation, I broke `cblack` into each separate thing it claimed to be. So there's a field for the channels, width, height, and the block data. Do you think we should provide some kind of helper method to assist in getting each block out of the `black_block_data` like an iterator?

Further down Colordata there's a `dng_levels` that has it's own struct. This has a `cblack`, too, which I have not split into separate fields. If you think the field-splitting is a good idea I'll go along and do that. Maybe there could be a `struct ChannelBlack` for the both of them?

__Libraw's linear_max__: `unsigned linear_max[4]`
I put a comment above this one in the code, too: The documentation says it's `unsigned` but `libraw-sys` gives it as an `i64`? I left it as an `[i64; 4]` in the struct.

__Libraw's model2, UniqueCameraModel, and LocalizedCameraModel__: all `[i8; 64]`
The latter two are DNG tag names and the former is the "Firmware revision (for some cameras)". It seems like these want to be strings. Should we provide a method like `OsString` has [`to_string_lossy`](https://doc.rust-lang.org/std/ffi/struct.OsString.html#method.to_string_lossy) and [`into_string`](https://doc.rust-lang.org/std/ffi/struct.OsString.html#method.into_string)?

__Libraw's profile__: `void *profile`
> Pointer to the retrieved ICC profile (if it is present in the RAW file).

So this one is weird. There is a value after it that gives the length so I create a slice using unsafe code and then clone it with `to_vec`. I am pretty sure this operation is safe but I am not certain. How would you handle this?

### Inconsistent names
Libraw is reasonably consistent with their names, but it does not fit with Rust's conventions and rustfmt gets mad. It seems that they use the exif tag name if that field is directly from the exif data and snake_case otherwise. Should we snake-caseify these names or is the `#[allow(non_snake_case)]` annotation fine?

Also there's a `model2` but no `model`?

### Misc. Question
In trying to document the colordata struct, I realized I'm not very certain at all what some of the fields indicate.

In our Colordata there's a `black_per_channel` which is the extracted values from `cblack`. It says **per-channel** but it has four values. So it's probably not RGB, right? And the values are... not what I'd expect. I tried to figure it out [here](https://github.com/gennyble/rawproc/issues/7#issuecomment-981233435) but have not come to any solid conclusions yet.

This has been a long PR message, so I might as well sign it like an email :3
I took a year to get this PR here so don't feel the need to rush to reply to it if that's something you might feel. I'm in no rush if you aren't.

~ Genevive