### PR TITLE
adding double gamma settings. By default settings for rec. BT.709 are…

### DIFF
--- a/libraw/examples/simple_process_8bit.rs
+++ b/libraw/examples/simple_process_8bit.rs
@@ -6,7 +6,11 @@ use libraw::Processor;
 fn main() {
     let buf = fs::read("raw.RW2").expect("read in");
 
-    let processor = Processor::new();
+    let mut processor = Processor::new();
+
+    processor.gamma(2.4, 12.92); // before starting processing we can set gamma. See double gamma explaination here https://www.libraw.org/docs/API-datastruct-eng.html
+                                                // if gamma values is not set by you processor use defaulf values power 2.222 and slope 4.5 
+                                                
     let processed = processor.process_8bit(&buf).expect("processing successful");
 
     let mut out = File::create("out_8bit.ppm").expect("create out");

--- a/libraw/src/processor.rs
+++ b/libraw/src/processor.rs
@@ -13,6 +13,16 @@ impl Processor {
         Self { inner }
     }
 
+    pub fn gamma(&mut self, mut gamm_0: f64, gamm_1: f64) {
+
+        if gamm_0 != 0.0 { gamm_0 = 1.0 / gamm_0; }
+
+        unsafe {
+            (*self.inner).params.gamm[0] = gamm_0;
+            (*self.inner).params.gamm[1] = gamm_1;
+        };
+    }
+
     fn open(&self, buf: &[u8]) -> Result<()> {
         Error::check(unsafe {
             sys::libraw_open_buffer(self.inner, buf.as_ptr() as *const _, buf.len())


### PR DESCRIPTION
… used: power 2.222(i.e. gamm_0=2.222)  and slope 4.5. For sRGB curve use gamm_0=2.4 and gamm_1=12.92, for linear curve set gamm_0/gamm_1 to 1.0.0