### PR TITLE
Gamma settings for RAW decoding + convertion to jpeg sample

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -1,0 +1,90 @@
+name: RS
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+
+env:
+  RUST_BACKTRACE: full
+
+jobs:
+  rustfmt:
+    name: rustfmt / linux / stable
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install rust
+        run: |
+          rustup update --no-self-update stable
+          rustup component add rustfmt
+
+      - name: cargo fmt
+        run: |
+          cargo fmt --all -- --check
+
+  clippy:
+    name: clippy / linux / stable
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install rust
+        run: |
+          rustup update --no-self-update stable
+          rustup component add clippy
+
+      - name: cargo clippy
+        run: |
+          cargo clippy --all --all-targets
+
+  test:
+    name: test / ${{ matrix.name }}
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux / stable
+            rust: stable
+          - name: linux / beta
+            rust: beta
+          - name: linux / nightly
+            rust: nightly
+          - name: linux / 1.63.0
+            rust: 1.63.0
+          - name: macOS / stable
+            os: macOS-latest
+          # TODO: fix
+          # - name: windows / stable
+          #   os: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install rust
+        run: |
+          rustup default ${{ matrix.rust }}
+          rustup update --no-self-update ${{ matrix.rust }}
+
+      - name: Use regex 1.9.6 (MSRV)
+        if: matrix.rust == '1.63.0'
+        run: cargo update -p regex --precise 1.9.6
+
+      - name: Test (builtin bindings)
+        run: cargo test --all
+
+      - name: Test (regenerate bindings)
+        run: cargo test --all --features bindgen

--- a/libraw/Cargo.toml
+++ b/libraw/Cargo.toml
@@ -16,6 +16,7 @@ name = "libraw"
 
 [dependencies]
 libraw-rs-sys = { version = "0.0.4", path = "../libraw-sys" }
+mozjpeg = "0.10.7"
 
 [features]
 bindgen = ["libraw-rs-sys/bindgen"]

--- a/libraw/examples/convert_to_jpg.rs
+++ b/libraw/examples/convert_to_jpg.rs
@@ -1,0 +1,32 @@
+/// This is simple converion without metadata 
+use std::fs::{self, File};
+use std::io::Write;
+
+use libraw::Processor;
+
+fn main() {
+    let buf = fs::read("/home/nikita/Desktop/Rust/libraw-rs/samples/images/colorchart-eos-7d.cr2").expect("read in");
+
+    let mut processor = Processor::new();
+
+    processor.gamma(2.4, 12.92); // before starting processing we can set gamma. See double gamma explaination here https://www.libraw.org/docs/API-datastruct-eng.html
+                                                // if gamma values is not set by you processor use defaulf values power 2.222 and slope 4.5 
+                                                
+    let processed = processor.process_8bit(&buf).expect("processing successful");
+
+    let to_compress_data: Vec<u8> = Vec::new(); // new variable for compression
+
+    let mut encode = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_EXT_RGB);
+    encode.set_size(processed.width() as usize, processed.height() as usize);
+    encode.set_quality(100.0);
+
+    let mut comp = encode.start_compress(to_compress_data).expect("Starting compression error!");
+    let pixels = processed.pixels().unwrap();
+    //let pixels = &*processed;  // another way to make link on data
+    comp.write_scanlines(&pixels[..]).unwrap();
+
+    let compressed = comp.finish().unwrap();
+
+    let mut out = File::create("no_metadata_image.jpg").expect("create out");
+    out.write_all(&compressed).expect("pixels");
+}

--- a/libraw/examples/convert_to_jpg.rs
+++ b/libraw/examples/convert_to_jpg.rs
@@ -1,17 +1,18 @@
-/// This is simple converion without metadata 
+/// This is simple converion without metadata
 use std::fs::{self, File};
 use std::io::Write;
 
 use libraw::Processor;
 
 fn main() {
-    let buf = fs::read("/home/nikita/Desktop/Rust/libraw-rs/samples/images/colorchart-eos-7d.cr2").expect("read in");
+    let buf = fs::read("/home/nikita/Desktop/Rust/libraw-rs/samples/images/colorchart-eos-7d.cr2")
+        .expect("read in");
 
     let mut processor = Processor::new();
 
     processor.gamma(2.4, 12.92); // before starting processing we can set gamma. See double gamma explaination here https://www.libraw.org/docs/API-datastruct-eng.html
-                                                // if gamma values is not set by you processor use defaulf values power 2.222 and slope 4.5 
-                                                
+                                 // if gamma values is not set by you processor use defaulf values power 2.222 and slope 4.5
+
     let processed = processor.process_8bit(&buf).expect("processing successful");
 
     let to_compress_data: Vec<u8> = Vec::new(); // new variable for compression
@@ -20,7 +21,9 @@ fn main() {
     encode.set_size(processed.width() as usize, processed.height() as usize);
     encode.set_quality(100.0);
 
-    let mut comp = encode.start_compress(to_compress_data).expect("Starting compression error!");
+    let mut comp = encode
+        .start_compress(to_compress_data)
+        .expect("Starting compression error!");
     let pixels = processed.pixels().unwrap();
     //let pixels = &*processed;  // another way to make link on data
     comp.write_scanlines(&pixels[..]).unwrap();

--- a/libraw/src/image.rs
+++ b/libraw/src/image.rs
@@ -29,6 +29,20 @@ impl<T: BitDepth> ProcessedImage<T> {
     pub fn height(&self) -> u32 {
         unsafe { (*self.inner).height }.into()
     }
+
+    pub fn colors(&self) -> u16 {
+        unsafe { (*self.inner).colors }
+    }
+
+    pub fn pixels(&self) -> Option<&[u8]> {
+        let pixels = unsafe {
+            slice::from_raw_parts(
+                (*self.inner).data.as_ptr(),
+                (*self.inner).data_size as usize,
+            )
+        };
+        Some(pixels)
+    }
 }
 
 impl Deref for ProcessedImage<u8> {

--- a/libraw/src/processor.rs
+++ b/libraw/src/processor.rs
@@ -14,11 +14,9 @@ impl Processor {
     }
 
     pub fn gamma(&mut self, mut gamm_0: f64, gamm_1: f64) {
-
         if gamm_0 != 0.0 {
             gamm_0 = 1.0 / gamm_0;
         }
-
         unsafe {
             (*self.inner).params.gamm[0] = gamm_0;
             (*self.inner).params.gamm[1] = gamm_1;

--- a/libraw/src/processor.rs
+++ b/libraw/src/processor.rs
@@ -13,6 +13,18 @@ impl Processor {
         Self { inner }
     }
 
+    pub fn gamma(&mut self, mut gamm_0: f64, gamm_1: f64) {
+
+        if gamm_0 != 0.0 {
+            gamm_0 = 1.0 / gamm_0;
+        }
+
+        unsafe {
+            (*self.inner).params.gamm[0] = gamm_0;
+            (*self.inner).params.gamm[1] = gamm_1;
+        };
+    }
+
     fn open(&self, buf: &[u8]) -> Result<()> {
         Error::check(unsafe {
             sys::libraw_open_buffer(self.inner, buf.as_ptr() as *const _, buf.len())


### PR DESCRIPTION
It was some difficulties for me to understand 'Actions' on github, but now it is all fine. 

Test please this version. The only thing couldn't pass the test is mozjpeg in sample, which demands rust 1.71 and above. 

So. 

For RAW to jpg convertion here is a new sample.

For gamma. By default settings for rec. BT.709 areused: power 2.222(i.e. gamm_0=2.222) and slope 4.5. For sRGB curve use gamm_0=2.4 and gamm_1=12.92, for linear curve set gamm_0/gamm_1 to 1.0.0
